### PR TITLE
Removes google-oauth dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setuptools.setup(
         'gcp': [
             'dataclasses>=0.8; python_version=="3.6"',
             'google-auth>=1.6',
-            'google-oauth>=1.0',
         ],
     },
     python_requires='>=3.6',


### PR DESCRIPTION
`google-oauth` seems to be a dead project and is not/no longer used anywhere in this package. I'm having issues installing the package currently due to this dependency. I think the build is no longer available? My one hesitation is that I can't seem to find where this library was ever used so there may be something I'm missing. @hackermd can you shed any light on this?