### PR TITLE
Update deprecated numpy method calls

### DIFF
--- a/src/dicomweb_client/file.py
+++ b/src/dicomweb_client/file.py
@@ -857,7 +857,7 @@ class _DatabaseManager:
                                 getattr(ds, 'NumberOfFrames', '1')
                             ),
                             number_of_pixels_per_frame=int(
-                                np.product([
+                                np.prod([
                                     ds.Rows,
                                     ds.Columns,
                                     ds.SamplesPerPixel,
@@ -2027,7 +2027,7 @@ class _DatabaseManager:
                                 getattr(ds, 'NumberOfFrames', '1')
                             ),
                             number_of_pixels_per_frame=int(
-                                np.product([
+                                np.prod([
                                     ds.Rows,
                                     ds.Columns,
                                     ds.SamplesPerPixel


### PR DESCRIPTION
`numpy.product` was deprecated in favor of `numpy.prod` (see https://numpy.org/devdocs/release/1.25.0-notes.html)