### PR TITLE
Define JSON enconding to UTF-8

### DIFF
--- a/src/dicomweb_client/web.py
+++ b/src/dicomweb_client/web.py
@@ -577,6 +577,7 @@ class DICOMwebClient:
                 stream=stream
             )
             if response.content:
+                response.encoding = 'UTF-8'
                 decoded_response = response.json()
                 # All metadata resources are expected to be sent as a JSON
                 # array of DICOM data sets. However, some origin servers may
@@ -1587,9 +1588,9 @@ class DICOMwebClient:
         response = _invoke_delete_request(url)
         if response.status_code == HTTPStatus.METHOD_NOT_ALLOWED:
             logger.error(
-              'Resource could not be deleted. '
-              'The origin server may not support deletion '
-              'or you may not have the necessary permissions.'
+                'Resource could not be deleted. '
+                'The origin server may not support deletion '
+                'or you may not have the necessary permissions.'
             )
         response.raise_for_status()
         return response
@@ -2045,7 +2046,7 @@ class DICOMwebClient:
         """
         if study_instance_uid is None:
             raise ValueError(
-              'Study Instance UID is required for deletion of a study.'
+                'Study Instance UID is required for deletion of a study.'
             )
         url = self._get_studies_url(_Transaction.DELETE, study_instance_uid)
         self._http_delete(url)
@@ -2440,7 +2441,7 @@ class DICOMwebClient:
         """
         if study_instance_uid is None:
             raise ValueError(
-              'Study Instance UID is required for deletion of a series.'
+                'Study Instance UID is required for deletion of a series.'
             )
         if series_instance_uid is None:
             raise ValueError(
@@ -2683,7 +2684,7 @@ class DICOMwebClient:
         """
         if study_instance_uid is None:
             raise ValueError(
-              'Study Instance UID is required for deletion of an instance.'
+                'Study Instance UID is required for deletion of an instance.'
             )
         if series_instance_uid is None:
             raise ValueError(


### PR DESCRIPTION
**Pull Request Summary:**

The current implementation of `response.json()` from  the `requests` module involves time-consuming charset detection, particularly problematic when handling a large number of requests. (For more details, see this Stack Overflow discussion: [Stack Overflow - Performance Issues When Formatting Using JSON](https://stackoverflow.com/questions/32016218/performance-issues-formatting-using-json)).

This pull request introduces an enhancement to the `dicomweb-client` module, specifying the character set and bypass charset detection. This improvement can significantly boost performance. This is compatibledwith the `requests` module (https://docs.python-requests.org/en/latest/user/quickstart/#response-content)

In the specific case of DICOMWEB, the presence of the UTF-8 charset in every response is guaranteed, as dictated by the DICOM standard. More information about this requirement can be found in the DICOM standard documentation: [DICOM Standard - Section F.2](https://dicom.nema.org/medical/dicom/current/output/chtml/part18/sect_F.2.html).

**Changes:**

- Enhanced the `dicomweb-client` module, specifying the character set.
- Improved performance when dealing with a high volume of requests.
- Assured UTF-8 charset in DICOMWEB responses as per the DICOM standard.

**Testing:**

All tests have passed successfully.

**Notes:**

Thank you for your attention to this matter.
