### PR TITLE
Support numpy >= 2.x on Python >= 3.8

### DIFF
--- a/src/dicomweb_client/file.py
+++ b/src/dicomweb_client/file.py
@@ -584,6 +584,10 @@ class _DatabaseManager:
             end = time.time()
             elapsed = round(end - start)
             logger.info(f'updated database in {elapsed} seconds')
+        # numpy 2 no longer has prod, but Python >= 3.8 does.  We either have
+        # one or the other, so use the python math.prod method when available
+        # and fall abck to np if not.
+        self._prod = math.prod if hasattr(math, 'prod') else np.prod
 
     def __getstate__(self) -> dict:
         """Customize state for serialization via pickle module.
@@ -857,12 +861,11 @@ class _DatabaseManager:
                                 getattr(ds, 'NumberOfFrames', '1')
                             ),
                             number_of_pixels_per_frame=int(
-                                (math.prod  # type: ignore
-                                 if hasattr(math, 'prod') else np.prod)([
+                                self._prod([  # type: ignore
                                     ds.Rows,
                                     ds.Columns,
                                     ds.SamplesPerPixel,
-                                 ])
+                                ])
                             ),
                             transfer_syntax_uid=transfer_syntax_uid,
                             bits_allocated=ds.BitsAllocated
@@ -2028,12 +2031,11 @@ class _DatabaseManager:
                                 getattr(ds, 'NumberOfFrames', '1')
                             ),
                             number_of_pixels_per_frame=int(
-                                (math.prod  # type: ignore
-                                 if hasattr(math, 'prod') else np.prod)([
+                                self._prod([  # type: ignore
                                     ds.Rows,
                                     ds.Columns,
                                     ds.SamplesPerPixel
-                                 ])
+                                ])
                             ),
                             transfer_syntax_uid=ds.file_meta.TransferSyntaxUID,
                             bits_allocated=ds.BitsAllocated

--- a/src/dicomweb_client/file.py
+++ b/src/dicomweb_client/file.py
@@ -565,6 +565,11 @@ class _DatabaseManager:
 
         self._create_db()
 
+        # numpy 2 no longer has prod, but Python >= 3.8 does.  We either have
+        # one or the other, so use the python math.prod method when available
+        # and fall abck to np if not.
+        self._prod = math.prod if hasattr(math, 'prod') else np.prod
+
         self._attributes = {
             _QueryResourceType.STUDIES: self._get_attributes(
                 _QueryResourceType.STUDIES
@@ -584,10 +589,6 @@ class _DatabaseManager:
             end = time.time()
             elapsed = round(end - start)
             logger.info(f'updated database in {elapsed} seconds')
-        # numpy 2 no longer has prod, but Python >= 3.8 does.  We either have
-        # one or the other, so use the python math.prod method when available
-        # and fall abck to np if not.
-        self._prod = math.prod if hasattr(math, 'prod') else np.prod
 
     def __getstate__(self) -> dict:
         """Customize state for serialization via pickle module.

--- a/src/dicomweb_client/file.py
+++ b/src/dicomweb_client/file.py
@@ -857,11 +857,12 @@ class _DatabaseManager:
                                 getattr(ds, 'NumberOfFrames', '1')
                             ),
                             number_of_pixels_per_frame=int(
-                                np.prod([
+                                (math.prod  # type: ignore
+                                 if hasattr(math, 'prod') else np.prod)([
                                     ds.Rows,
                                     ds.Columns,
                                     ds.SamplesPerPixel,
-                                ])
+                                 ])
                             ),
                             transfer_syntax_uid=transfer_syntax_uid,
                             bits_allocated=ds.BitsAllocated
@@ -2027,11 +2028,12 @@ class _DatabaseManager:
                                 getattr(ds, 'NumberOfFrames', '1')
                             ),
                             number_of_pixels_per_frame=int(
-                                np.prod([
+                                (math.prod  # type: ignore
+                                 if hasattr(math, 'prod') else np.prod)([
                                     ds.Rows,
                                     ds.Columns,
                                     ds.SamplesPerPixel
-                                ])
+                                 ])
                             ),
                             transfer_syntax_uid=ds.file_meta.TransferSyntaxUID,
                             bits_allocated=ds.BitsAllocated

--- a/src/dicomweb_client/file.py
+++ b/src/dicomweb_client/file.py
@@ -568,7 +568,7 @@ class _DatabaseManager:
         # numpy 2 no longer has prod, but Python >= 3.8 does.  We either have
         # one or the other, so use the python math.prod method when available
         # and fall abck to np if not.
-        self._prod = math.prod if hasattr(math, 'prod') else np.prod
+        self._prod = getattr(math, 'prod', np.prod)
 
         self._attributes = {
             _QueryResourceType.STUDIES: self._get_attributes(


### PR DESCRIPTION
This switches from np.prod to math.prod when math.prod exists (Python >= 3.8).  With this change, the tests all pass with numpy >= 2.  Note that numpy 2 doesn't exist for Python < 3.8, so this is a safe check.

Closes #100.