### PR TITLE
Modernize packaging, add support for new python versions, prepare for 0.59.2 release

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -15,7 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: [
+          "3.7",
+          "3.8",
+          "3.9",
+          "3.10",
+          "3.11",
+          "3.12",
+          "3.13"
+        ]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,7 +34,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools
-        pip install -r requirements_test.txt
+        pip install '.[test]'
         pip install .
     - name: Lint with flake8
       run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,14 +1,16 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
-    python: "3.8"
+    python: "3.11"
 
 python:
   install:
-    - requirements: requirements_docs.txt
-    - path: .
+    - method: pip
+      path: .
+      extra_requirements:
+      - docs
 
 sphinx:
   configuration: docs/conf.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include src/dicomweb_client/*

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -7,13 +7,16 @@ Source code is available at Github and can be cloned via git:
 
 .. code-block:: none
 
-    git clone https://github.com/ImagingDataCommons/dicomweb-client ~/dicomweb-client
+    git clone https://github.com/ImagingDataCommons/dicomweb-client /path/to/dicomweb-client
+
+where `/path/to/dicomweb-client` is a suitable path on your system where you
+wish to clone the repository.
 
 The :mod:`dicomweb_client` package can be installed in *develop* mode for local development:
 
 .. code-block:: none
 
-    pip install -e ~/dicomweb-client
+    pip install -e /path/to/dicomweb-client
 
 
 .. _pull-requests:
@@ -54,13 +57,13 @@ Install requirements:
 
 .. code-block:: none
 
-    pip install -r ~/dicomweb-client/requirements_test.txt
+    pip install '/path/to/dicomweb-client[test]'
 
 Run tests (including checks for PEP8 compliance):
 
 .. code-block:: none
 
-    cd ~/dicomweb-client
+    cd /path/to/dicomweb-client
     pytest --flake8
 
 .. _building-documentation:
@@ -72,13 +75,13 @@ Install requirements:
 
 .. code-block:: none
 
-    pip install -r ~/dicomweb-client/requirements_docs.txt
+    pip install '/path/to/dicomweb-client[docs]'
 
 Build documentation in *HTML* format:
 
 .. code-block:: none
 
-    cd ~/dicomweb-client
+    cd /path/to/dicomweb-client
     sphinx-build -b html docs/ docs/build/
 
 The built ``index.html`` file will be located in ``docs/build``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ test = [
     "mypy==0.982",
     "pytest==7.1.3",
     "pytest-cov==3.0.0",
-    "pytest-flake8==1.1.1",
+    "pytest-flake8==1.2.2",
     "pytest-localserver==0.5.0",
     "types-requests==2.27.14",
     "types-Pillow==9.0.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ test = [
     "mypy==0.982",
     "pytest==7.1.3",
     "pytest-cov==3.0.0",
-    "pytest-flake8==1.2.2",
+    "pytest-flake8==1.1.3",
     "pytest-localserver==0.5.0",
     "types-requests==2.27.14",
     "types-Pillow==9.0.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,100 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dicomweb-client"
+version = "0.59.2"
+description = "Client for DICOMweb RESTful services."
+readme = "README.md"
+requires-python = ">=3.6"
+authors = [
+    { name = "Markus D. Herrmann" },
+]
+maintainers = [
+    { name = "Markus D. Herrmann" },
+    { name = "Christopher P. Bridge" },
+    { name = "Steve Pieper" },
+]
+license = { text = "LICENSE" }
+classifiers = [
+    "Environment :: Web Environment",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Intended Audience :: Science/Research",
+    "Topic :: Internet :: WWW/HTTP",
+    "Topic :: Multimedia :: Graphics",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
+dependencies = [
+    "numpy>=1.19",
+    "requests>=2.18",
+    "retrying>=1.3.3",
+    "Pillow>=8.3",
+    "pydicom>=2.2",
+    "typing-extensions>=4.0; python_version < '3.8.0'",
+]
+
+[project.optional-dependencies]
+gcp = [
+    "dataclasses>=0.8; python_version=='3.6'",
+    "google-auth>=1.6",
+]
+test = [
+    "mypy==0.982",
+    "pytest==7.1.3",
+    "pytest-cov==3.0.0",
+    "pytest-flake8==1.1.1",
+    "pytest-localserver==0.5.0",
+    "types-requests==2.27.14",
+    "types-Pillow==9.0.8",
+]
+docs = [
+    "sphinx-pyreverse==0.0.17",
+    "sphinx-rtd-theme==1.0.0",
+    "sphinxcontrib-autoprogram==0.1.7",
+    "sphinxcontrib-websupport==1.2.4",
+    "sphinx-autodoc-typehints==1.12.0",
+]
+
+[project.scripts]
+dicomweb-client = "dicomweb_client.cli:_main"
+
+[project.urls]
+homepage = "https://github.com/imagingdatacommons/dicomweb-client"
+documentation = "https://dicomweb-client.readthedocs.io/"
+repository = "https://github.com/ImagingDataCommons/dicomweb-client.git"
+
+[tool.pytest.ini_options]
+minversion = "7"
+addopts = ["--doctest-modules", "-ra", "--strict-config", "--strict-markers"]
+testpaths = ["tests"]
+log_cli_level = "INFO"
+xfail_strict = true
+
+[tool.mypy]
+warn_unreachable = true
+enable_error_code = ["redundant-expr", "truthy-bool"]
+
+[[tool.mypy.overrides]]
+module = "pydicom.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "google.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "retrying.*"
+ignore_missing_imports = true

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,5 +1,0 @@
-sphinx-pyreverse==0.0.17
-sphinx-rtd-theme==1.0.0
-sphinxcontrib-autoprogram==0.1.7
-sphinxcontrib-websupport==1.2.4
-sphinx-autodoc-typehints==1.12.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,0 @@
-mypy==0.982
-pytest==7.1.3
-pytest-cov==3.0.0
-pytest-flake8==1.1.1
-pytest-localserver==0.5.0
-types-requests==2.27.14
-types-Pillow==9.0.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,19 +5,3 @@ test=pytest
 max_line_length = 80
 ignore = E121 E125 W504
 statistics = True
-
-[mypy]
-warn_unreachable = True
-
-[mypy-google.*]
-ignore_missing_imports = True
-
-[mypy-pydicom.*]
-ignore_missing_imports = True
-
-[mypy-retrying.*]
-ignore_missing_imports = True
-
-[tool:pytest]
-python_files = tests/*.py
-log_cli_level = INFO

--- a/src/dicomweb_client/__init__.py
+++ b/src/dicomweb_client/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.59.1'
+__version__ = '0.59.2'
 
 from dicomweb_client.api import DICOMwebClient, DICOMfileClient
 from dicomweb_client.protocol import DICOMClient

--- a/src/dicomweb_client/web.py
+++ b/src/dicomweb_client/web.py
@@ -877,9 +877,7 @@ class DICOMwebClient:
         media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None]
             Acceptable media types and optionally the UIDs of the corresponding
             transfer syntaxes
-        supported_media_types: Union[
-            Mapping[str, Union[str, Tuple[str, ...]]], Set[str]
-        ]
+        supported_media_types: Union[Mapping[str, Union[str, Tuple[str, ...]]], Set[str]]
             Set of supported media types or mapping of transfer syntaxes
             to their corresponding media types
 
@@ -888,7 +886,7 @@ class DICOMwebClient:
         str
             Accept header field value
 
-        """
+        """  # noqa: E501
         if not isinstance(media_types, (list, tuple, set)):
             raise TypeError(
                 'Acceptable media types must be provided as a sequence.'


### PR DESCRIPTION
I think it makes sense to move to the `pyproject.toml` standard for the next release (0.59.2). This PR replaces the functionality of the following files with a new `pyproject.toml`:

- `setup.py`
- `requirements_test.txt`
- `requirements_docs.txt`
- `Manifest.in`
- `setup.cfg` (since flake8 does not support `pyproject.toml` yet, I cannot remove this file entirely)

The github workflows, developer guide and `.readthedocs.yaml` have been updated to accommodate these changes.

Additionally I added explicit support for newer python versions (3.11, 3.12, 3.13) by listing them in the `pyproject.toml` and additionally adding tests for those version in the github actions.

Finally, version bumping for the imminent `0.59.2` release