### PR TITLE
Revert CLI name from dicomweb-client to dicomweb_client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ docs = [
 ]
 
 [project.scripts]
-dicomweb-client = "dicomweb_client.cli:_main"
+dicomweb_client = "dicomweb_client.cli:_main"
 
 [project.urls]
 homepage = "https://github.com/imagingdatacommons/dicomweb-client"


### PR DESCRIPTION
This was unintentional when redoing the packaging for 0.59.2 release. I suggest we change back and push out 0.59.3 asap. Thoughts @pieper, anyone else?

Brought to my attention by #103 