### PR TITLE
add test for retrieve study metadata

### DIFF
--- a/src/dicomweb_client/file.py
+++ b/src/dicomweb_client/file.py
@@ -2726,7 +2726,7 @@ class DICOMfileClient:
                 study_instance_uid=study_instance_uid
             )
             collection = []
-            for series_instance_uid, study_instance_uid in series_identifiers:
+            for study_instance_uid, series_instance_uid in series_identifiers:
                 collection.extend(
                     self.retrieve_series_metadata(
                         study_instance_uid=study_instance_uid,

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -178,6 +178,25 @@ def test_search_for_instances_in_series(file_client):
         for attr in STUDY_ATTRIBUTES:
             assert not hasattr(test_instance_pydicom, attr)
 
+def test_retrieve_study_metadata(file_client):
+    instances = file_client.retrieve_study_metadata(
+        '1.3.6.1.4.1.5962.1.1.0.0.0.1196530851.28319.0.1',
+    )
+    assert isinstance(instances, list)
+    assert len(instances) > 0
+
+    for test_instance_json in instances:
+        assert isinstance(test_instance_json, dict)
+        test_instance_pydicom = Dataset.from_json(test_instance_json)
+        attributes = {
+            'SOPClassUID',
+            'SOPInstanceUID',
+            'SeriesInstanceUID',
+            'StudyInstanceUID',
+        }
+        for attr in attributes:
+            assert hasattr(test_instance_pydicom, attr)
+
 
 def test_retrieve_series_metadata(file_client):
     instances = file_client.retrieve_series_metadata(


### PR DESCRIPTION
The return statement [here](https://github.com/ImagingDataCommons/dicomweb-client/blob/99aa011b428249febdaca1f4ab959453754be961/src/dicomweb_client/file.py#L1314-L1320) returns a tuple with (StudyInstanceUid, SeriesInstanceUid) but after it is called in `retrieve_study_metadata` is it extracted in opposite direction [here](https://github.com/ImagingDataCommons/dicomweb-client/blob/99aa011b428249febdaca1f4ab959453754be961/src/dicomweb_client/file.py#L2729)

I've also added appropriate unit tests. 
