### PR TITLE
Remove EOL python versions from tests

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -16,8 +16,6 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          "3.7",
-          "3.8",
           "3.9",
           "3.10",
           "3.11",

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -178,6 +178,7 @@ def test_search_for_instances_in_series(file_client):
         for attr in STUDY_ATTRIBUTES:
             assert not hasattr(test_instance_pydicom, attr)
 
+
 def test_retrieve_study_metadata(file_client):
     instances = file_client.retrieve_study_metadata(
         '1.3.6.1.4.1.5962.1.1.0.0.0.1196530851.28319.0.1',


### PR DESCRIPTION
Unit tests are failing because python 3.7 and 3.8 are end of life. Remove these two python versions from the unit test configuration