### PR TITLE
Fix docstring comments about default transfer syntax: implicit -> explicit

### DIFF
--- a/src/dicomweb_client/protocol.py
+++ b/src/dicomweb_client/protocol.py
@@ -149,7 +149,7 @@ class DICOMClient(Protocol):
 
         Note
         ----
-        Instances are by default retrieved using Implicit VR Little Endian
+        Instances are by default retrieved using Explicit VR Little Endian
         transfer syntax (Transfer Syntax UID ``"1.2.840.10008.1.2"``). This
         means that Pixel Data of Image instances will be retrieved
         uncompressed. To retrieve instances in any available transfer syntax
@@ -182,7 +182,7 @@ class DICOMClient(Protocol):
 
         Note
         ----
-        Instances are by default retrieved using Implicit VR Little Endian
+        Instances are by default retrieved using Explicit VR Little Endian
         transfer syntax (Transfer Syntax UID ``"1.2.840.10008.1.2"``). This
         means that Pixel Data of Image instances will be retrieved
         uncompressed. To retrieve instances in any available transfer syntax
@@ -306,7 +306,7 @@ class DICOMClient(Protocol):
 
         Note
         ----
-        Instances are by default retrieved using Implicit VR Little Endian
+        Instances are by default retrieved using Explicit VR Little Endian
         transfer syntax (Transfer Syntax UID ``"1.2.840.10008.1.2"``). This
         means that Pixel Data of Image instances will be retrieved
         uncompressed. To retrieve instances in any available transfer syntax
@@ -342,7 +342,7 @@ class DICOMClient(Protocol):
 
         Note
         ----
-        Instances are by default retrieved using Implicit VR Little Endian
+        Instances are by default retrieved using Explicit VR Little Endian
         transfer syntax (Transfer Syntax UID ``"1.2.840.10008.1.2"``). This
         means that Pixel Data of Image instances will be retrieved
         uncompressed. To retrieve instances in any available transfer syntax
@@ -512,7 +512,7 @@ class DICOMClient(Protocol):
 
         Note
         ----
-        Instances are by default retrieved using Implicit VR Little Endian
+        Instances are by default retrieved using Explicit VR Little Endian
         transfer syntax (Transfer Syntax UID ``"1.2.840.10008.1.2"``). This
         means that Pixel Data of Image instances will be retrieved
         uncompressed. To retrieve instances in any available transfer syntax

--- a/src/dicomweb_client/web.py
+++ b/src/dicomweb_client/web.py
@@ -2034,7 +2034,7 @@ class DICOMwebClient:
 
         Note
         ----
-        Instances are by default retrieved using Implicit VR Little Endian
+        Instances are by default retrieved using Explicit VR Little Endian
         transfer syntax (Transfer Syntax UID ``"1.2.840.10008.1.2"``). This
         means that Pixel Data of Image instances will be retrieved
         uncompressed. To retrieve instances in any available transfer syntax
@@ -2077,7 +2077,7 @@ class DICOMwebClient:
 
         Note
         ----
-        Instances are by default retrieved using Implicit VR Little Endian
+        Instances are by default retrieved using Explicit VR Little Endian
         transfer syntax (Transfer Syntax UID ``"1.2.840.10008.1.2"``). This
         means that Pixel Data of Image instances will be retrieved
         uncompressed. To retrieve instances in any available transfer syntax
@@ -2361,7 +2361,7 @@ class DICOMwebClient:
 
         Note
         ----
-        Instances are by default retrieved using Implicit VR Little Endian
+        Instances are by default retrieved using Explicit VR Little Endian
         transfer syntax (Transfer Syntax UID ``"1.2.840.10008.1.2"``). This
         means that Pixel Data of Image instances will be retrieved
         uncompressed. To retrieve instances in any available transfer syntax
@@ -2408,7 +2408,7 @@ class DICOMwebClient:
 
         Note
         ----
-        Instances are by default retrieved using Implicit VR Little Endian
+        Instances are by default retrieved using Explicit VR Little Endian
         transfer syntax (Transfer Syntax UID ``"1.2.840.10008.1.2"``). This
         means that Pixel Data of Image instances will be retrieved
         uncompressed. To retrieve instances in any available transfer syntax
@@ -2714,7 +2714,7 @@ class DICOMwebClient:
 
         Note
         ----
-        Instances are by default retrieved using Implicit VR Little Endian
+        Instances are by default retrieved using Explicit VR Little Endian
         transfer syntax (Transfer Syntax UID ``"1.2.840.10008.1.2"``). This
         means that Pixel Data of Image instances will be retrieved
         uncompressed. To retrieve instances in any available transfer syntax


### PR DESCRIPTION
Fix for #91 