### PR TITLE
feat: add permissive UID validation for DicomWebClient

### DIFF
--- a/src/dicomweb_client/uri.py
+++ b/src/dicomweb_client/uri.py
@@ -629,12 +629,13 @@ def _validate_resource_identifiers_and_suffix(
 
 def _validate_uid(uid: str, permissive: bool) -> None:
     """Validates a DICOM UID."""
-    if len(uid) > _MAX_UID_LENGTH:
-        raise ValueError('UID cannot have more than 64 chars. '
-                         f'Actual count in {uid!r}: {len(uid)}')
-    if not permissive and _REGEX_UID.fullmatch(uid) is None:
-        raise ValueError(f'UID {uid!r} must match regex {_REGEX_UID!r} in '
-                         'conformance with the DICOM Standard.')
+    if not permissive:
+        if len(uid) > _MAX_UID_LENGTH:
+            raise ValueError('UID cannot have more than 64 chars. '
+                             f'Actual count in {uid!r}: {len(uid)}')
+        if _REGEX_UID.fullmatch(uid) is None:
+            raise ValueError(f'UID {uid!r} must match regex {_REGEX_UID!r} in '
+                            'conformance with the DICOM Standard.')
     elif permissive and _REGEX_PERMISSIVE_UID.fullmatch(uid) is None:
         raise ValueError(f'Permissive mode is enabled. UID {uid!r} must match '
                          f'regex {_REGEX_PERMISSIVE_UID!r}.')

--- a/src/dicomweb_client/uri.py
+++ b/src/dicomweb_client/uri.py
@@ -629,6 +629,8 @@ def _validate_resource_identifiers_and_suffix(
 
 def _validate_uid(uid: str, permissive: bool) -> None:
     """Validates a DICOM UID."""
+    if not isinstance(uid, str):
+        raise TypeError('DICOM UID must be a string.')
     if not permissive:
         if len(uid) > _MAX_UID_LENGTH:
             raise ValueError('UID cannot have more than 64 chars. '

--- a/src/dicomweb_client/uri.py
+++ b/src/dicomweb_client/uri.py
@@ -638,7 +638,7 @@ def _validate_uid(uid: str, permissive: bool) -> None:
         if _REGEX_UID.fullmatch(uid) is None:
             raise ValueError(f'UID {uid!r} must match regex {_REGEX_UID!r} in '
                              'conformance with the DICOM Standard.')
-    elif permissive and _REGEX_PERMISSIVE_UID.fullmatch(uid) is None:
+    elif _REGEX_PERMISSIVE_UID.fullmatch(uid) is None:
         raise ValueError(f'Permissive mode is enabled. UID {uid!r} must match '
                          f'regex {_REGEX_PERMISSIVE_UID!r}.')
 

--- a/src/dicomweb_client/uri.py
+++ b/src/dicomweb_client/uri.py
@@ -637,7 +637,7 @@ def _validate_uid(uid: str, permissive: bool) -> None:
                              f'Actual count in {uid!r}: {len(uid)}')
         if _REGEX_UID.fullmatch(uid) is None:
             raise ValueError(f'UID {uid!r} must match regex {_REGEX_UID!r} in '
-                            'conformance with the DICOM Standard.')
+                             'conformance with the DICOM Standard.')
     elif permissive and _REGEX_PERMISSIVE_UID.fullmatch(uid) is None:
         raise ValueError(f'Permissive mode is enabled. UID {uid!r} must match '
                          f'regex {_REGEX_PERMISSIVE_UID!r}.')

--- a/src/dicomweb_client/web.py
+++ b/src/dicomweb_client/web.py
@@ -32,7 +32,11 @@ import pydicom
 import requests
 import retrying
 
-from dicomweb_client.uri import build_query_string, parse_query_parameters, _validate_uid
+from dicomweb_client.uri import (
+    build_query_string,
+    parse_query_parameters,
+    _validate_uid
+)
 
 
 logger = logging.getLogger(__name__)
@@ -2172,7 +2176,6 @@ class DICOMwebClient:
             )
             url += f'?{additional_params_query_string}'
         self._http_delete(url)
-
 
     def search_for_series(
         self,

--- a/src/dicomweb_client/web.py
+++ b/src/dicomweb_client/web.py
@@ -236,7 +236,7 @@ class DICOMwebClient:
             when streaming data from the server using chunked transfer encoding
             (used by ``iter_*()`` methods as well as the ``store_instances()``
             method); defaults to ``10**6`` bytes (1MB)
-        permissive: bool, optional
+        permissive_uid: bool, optional
             If ``True``, relaxes the DICOM Standard validation for UIDs (see
             main docstring for details). This option is made available since
             users may be occasionally forced to work with DICOMs or services

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -70,6 +70,21 @@ def test_uid_permissive_invalid(uid):
         URI(_BASE_URL, uid, permissive=True)
 
 
+def test_uid_length_permissive():
+    """Tests that UIDs longer than 64 chars are allowed in permissive mode."""
+    # Create a UID with 65 characters
+    uid_65 = '1' * 65
+
+    # Should fail in strict mode
+    with pytest.raises(ValueError, match='UID cannot have more than 64 chars'):
+        URI(_BASE_URL, uid_65, permissive=False)
+
+    # Should succeed in permissive mode
+    URI(_BASE_URL, uid_65, permissive=True)
+    URI(_BASE_URL, '1.2.3', uid_65, permissive=True)
+    URI(_BASE_URL, '1.2.3', '4.5.6', uid_65, permissive=True)
+
+
 def test_uid_missing_error():
     """Checks *ValueError* is raised when an expected UID is missing."""
     with pytest.raises(ValueError, match='`study_instance_uid` missing with'):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1608,3 +1608,35 @@ def test_load_xml_response(httpserver, client, cache_dir):
         dataset = _load_xml_dataset(tree)
     assert dataset.RetrieveURL.startswith('https://wadors.hospital.com')
     assert len(dataset.ReferencedSOPSequence) == 2
+
+
+@pytest.mark.parametrize('invalid_uid', [
+    '1.2/3.4', '1.2@3.4', '1.2.a.4', '1.2.A.4', '.23.4', '1.2..4', '1.2.', '.'
+])
+def test_uid_strict_validation_fail(httpserver, invalid_uid):
+    client = DICOMwebClient(httpserver.url, permissive=False)
+    with pytest.raises(ValueError,
+                       match=f'UID {invalid_uid!r} must match regex'):
+        client.search_for_series(study_instance_uid=invalid_uid)
+
+
+@pytest.mark.parametrize('uid', ['13-abc', 'hello', 'is it', "you're me"])
+def test_uid_permissive_validation_pass(httpserver, uid):
+    client_strict = DICOMwebClient(httpserver.url, permissive=False)
+    client_permissive = DICOMwebClient(httpserver.url, permissive=True)
+
+    # Should fail in strict mode
+    with pytest.raises(ValueError, match=f'UID {uid!r} must match regex'):
+        client_strict.search_for_series(study_instance_uid=uid)
+
+    # Should not raise exception in permissive mode
+    resp = client_permissive.search_for_series(study_instance_uid=uid)
+    assert isinstance(resp, list)
+
+
+@pytest.mark.parametrize('uid', ['1.23.5@', '1/23.4'])
+def test_uid_permissive_validation_fail(httpserver, uid):
+    client = DICOMwebClient(httpserver.url, permissive=True)
+    with pytest.raises(ValueError,
+                       match=f'UID {uid!r} must match regex'):
+        client.search_for_series(study_instance_uid=uid)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1614,7 +1614,7 @@ def test_load_xml_response(httpserver, client, cache_dir):
     '1.2/3.4', '1.2@3.4', '1.2.a.4', '1.2.A.4', '.23.4', '1.2..4', '1.2.', '.'
 ])
 def test_uid_strict_validation_fail(httpserver, invalid_uid):
-    client = DICOMwebClient(httpserver.url, permissive=False)
+    client = DICOMwebClient(httpserver.url, permissive_uid=False)
     with pytest.raises(ValueError,
                        match=f'UID {invalid_uid!r} must match regex'):
         client.search_for_series(study_instance_uid=invalid_uid)
@@ -1622,8 +1622,8 @@ def test_uid_strict_validation_fail(httpserver, invalid_uid):
 
 @pytest.mark.parametrize('uid', ['13-abc', 'hello', 'is it', "you're me"])
 def test_uid_permissive_validation_pass(httpserver, uid):
-    client_strict = DICOMwebClient(httpserver.url, permissive=False)
-    client_permissive = DICOMwebClient(httpserver.url, permissive=True)
+    client_strict = DICOMwebClient(httpserver.url, permissive_uid=False)
+    client_permissive = DICOMwebClient(httpserver.url, permissive_uid=True)
 
     # Should fail in strict mode
     with pytest.raises(ValueError, match=f'UID {uid!r} must match regex'):
@@ -1636,7 +1636,7 @@ def test_uid_permissive_validation_pass(httpserver, uid):
 
 @pytest.mark.parametrize('uid', ['1.23.5@', '1/23.4'])
 def test_uid_permissive_validation_fail(httpserver, uid):
-    client = DICOMwebClient(httpserver.url, permissive=True)
+    client = DICOMwebClient(httpserver.url, permissive_uid=True)
     with pytest.raises(ValueError,
                        match=f'UID {uid!r} must match regex'):
         client.search_for_series(study_instance_uid=uid)


### PR DESCRIPTION
## Related Issue
Fixes #117 

## Changes
- Add `permissive` parameter to `DICOMwebClient` class
- Update the default regex to be more in line with `URI` class
- Add minimal units to test the changes