### PR TITLE
ENH: Replace pydicom deprecated usage of get_frame_offsets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "requests>=2.18",
     "retrying>=1.3.3",
     "Pillow>=8.3",
-    "pydicom>=2.2",
+    "pydicom>=3.0.0",
     "typing-extensions>=4.0; python_version < '3.8.0'",
 ]
 

--- a/src/dicomweb_client/file.py
+++ b/src/dicomweb_client/file.py
@@ -32,15 +32,7 @@ from pydicom import config as pydicom_config
 from pydicom.datadict import dictionary_VR, keyword_for_tag, tag_for_keyword
 from pydicom.dataelem import DataElement
 from pydicom.dataset import Dataset, FileMetaDataset
-from pydicom.encaps import encapsulate
-try:
-    # pydicom >= 3.0 - parse_basic_offsets replaces get_frame_offsets
-    from pydicom.encaps import parse_basic_offsets
-    _use_parse_basic_offsets = True
-except ImportError:
-    # pydicom < 3.0 - use deprecated get_frame_offsets
-    from pydicom.encaps import get_frame_offsets
-    _use_parse_basic_offsets = False
+from pydicom.encaps import encapsulate, parse_basic_offsets
 from pydicom.errors import InvalidDicomError
 from pydicom.filebase import DicomFileLike
 from pydicom.filereader import data_element_offset_to_value, dcmread
@@ -358,13 +350,7 @@ def _read_bot(fp: DicomFileLike) -> np.ndarray:
         fp.is_implicit_VR, 'OB'
     )
     fp.seek(pixel_data_element_value_offset - 4, 1)
-
-    # Use parse_basic_offsets for pydicom >= 3.0, get_frame_offsets for < 3.0
-    if _use_parse_basic_offsets:
-        offsets = parse_basic_offsets(fp)
-    else:
-        is_empty, offsets = get_frame_offsets(fp)
-
+    offsets = parse_basic_offsets(fp)
     return np.array(offsets, dtype=np.uint32)
 
 

--- a/src/dicomweb_client/file.py
+++ b/src/dicomweb_client/file.py
@@ -32,7 +32,15 @@ from pydicom import config as pydicom_config
 from pydicom.datadict import dictionary_VR, keyword_for_tag, tag_for_keyword
 from pydicom.dataelem import DataElement
 from pydicom.dataset import Dataset, FileMetaDataset
-from pydicom.encaps import encapsulate, get_frame_offsets
+from pydicom.encaps import encapsulate
+try:
+    # pydicom >= 3.0 - parse_basic_offsets replaces get_frame_offsets
+    from pydicom.encaps import parse_basic_offsets
+    _use_parse_basic_offsets = True
+except ImportError:
+    # pydicom < 3.0 - use deprecated get_frame_offsets
+    from pydicom.encaps import get_frame_offsets
+    _use_parse_basic_offsets = False
 from pydicom.errors import InvalidDicomError
 from pydicom.filebase import DicomFileLike
 from pydicom.filereader import data_element_offset_to_value, dcmread
@@ -350,7 +358,13 @@ def _read_bot(fp: DicomFileLike) -> np.ndarray:
         fp.is_implicit_VR, 'OB'
     )
     fp.seek(pixel_data_element_value_offset - 4, 1)
-    is_empty, offsets = get_frame_offsets(fp)
+
+    # Use parse_basic_offsets for pydicom >= 3.0, get_frame_offsets for < 3.0
+    if _use_parse_basic_offsets:
+        offsets = parse_basic_offsets(fp)
+    else:
+        is_empty, offsets = get_frame_offsets(fp)
+
     return np.array(offsets, dtype=np.uint32)
 
 

--- a/src/dicomweb_client/file.py
+++ b/src/dicomweb_client/file.py
@@ -392,9 +392,14 @@ def _build_bot(
         When the number of offsets doesn't match the specified number of frames
 
     """
-    initial_position = fp.tell()
-    offset_values = []
-    current_offset = 0
+      initial_position = fp.tell()
+
+    # We will keep two lists, one of all fragment boundaries (regardless of
+    # whether or not they are frame boundaries) and the other of just those
+    # fragment boundaries that are known to be frame boundaries (as identified
+    # by JPEG start markers).
+    frame_offset_values = []
+    fragment_offset_values = []
     i = 0
     while True:
         frame_position = fp.tell()
@@ -421,31 +426,34 @@ def _build_bot(
                 f'Length of Frame item #{i} is zero.'
             )
 
+        current_offset = frame_position - initial_position
+        fragment_offset_values.append(current_offset)
+
         first_two_bytes = fp.read(2)
         if not fp.is_little_endian:
             first_two_bytes = first_two_bytes[::-1]
-
-        current_offset = frame_position - initial_position
-        if transfer_syntax_uid == RLELossless:
-            offset_values.append(current_offset)
-        else:
-            # In case of fragmentation, we only want to get the offsets to the
-            # first fragment of a given frame. We can identify those based on
-            # the JPEG and JPEG 2000 markers that should be found at the
-            # beginning and end of the compressed byte stream.
-            if first_two_bytes in _START_MARKERS:
-                offset_values.append(current_offset)
+        # In case of fragmentation, we only want to get the offsets to the
+        # first fragment of a given frame. We can identify those based on
+        # the JPEG and JPEG 2000 markers that should be found at the
+        # beginning and end of the compressed byte stream.
+        if first_two_bytes in _START_MARKERS:
+            frame_offset_values.append(current_offset)
 
         i += 1
         fp.seek(length - 2, 1)  # minus the first two bytes
 
-    if len(offset_values) != number_of_frames:
+    if len(frame_offset_values) == number_of_frames:
+        basic_offset_table = frame_offset_values
+    elif len(fragment_offset_values) == number_of_frames:
+        # This covers RLE and others that have no frame markers but have a
+        # single fragment per frame
+        basic_offset_table = fragment_offset_values
+    else:
         raise ValueError(
             'Number of found frame items does not match specified number '
-            f'of frames: {len(offset_values)} instead of {number_of_frames}.'
+            f'of frames: {len(frame_offset_values)} instead of '
+            f'{number_of_frames}.'
         )
-    else:
-        basic_offset_table = offset_values
 
     fp.seek(initial_position, 0)
     return np.array(basic_offset_table, dtype=np.uint32)

--- a/src/dicomweb_client/file.py
+++ b/src/dicomweb_client/file.py
@@ -45,7 +45,7 @@ from pydicom.tag import (
     Tag,
     TupleTag,
 )
-from pydicom.uid import UID, RLELossless
+from pydicom.uid import UID
 from pydicom.valuerep import DA, DT, TM
 
 from dicomweb_client.uri import build_query_string, parse_query_parameters

--- a/src/dicomweb_client/file.py
+++ b/src/dicomweb_client/file.py
@@ -392,7 +392,7 @@ def _build_bot(
         When the number of offsets doesn't match the specified number of frames
 
     """
-      initial_position = fp.tell()
+    initial_position = fp.tell()
 
     # We will keep two lists, one of all fragment boundaries (regardless of
     # whether or not they are frame boundaries) and the other of just those
@@ -432,6 +432,7 @@ def _build_bot(
         first_two_bytes = fp.read(2)
         if not fp.is_little_endian:
             first_two_bytes = first_two_bytes[::-1]
+
         # In case of fragmentation, we only want to get the offsets to the
         # first fragment of a given frame. We can identify those based on
         # the JPEG and JPEG 2000 markers that should be found at the

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1537,7 +1537,7 @@ def test_delete_instance_error_with_additional_params(
 
 
 def test_load_json_dataset_da(httpserver, client, cache_dir):
-    value = ['2018-11-21']
+    value = ['20181121']  # DA format must be YYYYMMDD
     dicom_json = {
         '00080020': {
             'vr': 'DA',

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -776,10 +776,20 @@ def test_retrieve_instance_singlepart(httpserver, client, cache_dir):
     cache_filename = str(cache_dir.joinpath('file.dcm'))
     with open(cache_filename, 'rb') as f:
         data = f.read()
+    media_type = 'application/dicom'
+    boundary = 'boundary'
     headers = {
-        'content-type': 'application/dicom'
+        'content-type': (
+            'multipart/related; '
+            f'type="{media_type}"; '
+            f'boundary="{boundary}"'
+        ),
     }
-    httpserver.serve_content(content=data, code=200, headers=headers)
+    message = DICOMwebClient._encode_multipart_message(
+        content=[data],
+        content_type=headers['content-type']
+    )
+    httpserver.serve_content(content=message, code=200, headers=headers)
     study_instance_uid = '1.2.3'
     series_instance_uid = '1.2.4'
     sop_instance_uid = '1.2.5'

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1285,8 +1285,8 @@ def test_retrieve_instance_frames_rendered_png(httpserver, client, cache_dir):
 
 def test_store_instance_error_with_retries(httpserver, client, cache_dir):
     dataset = pydicom.Dataset.from_json({})
-    dataset.is_little_endian = True
-    dataset.is_implicit_VR = True
+    dataset.file_meta = pydicom.dataset.FileMetaDataset()
+    dataset.file_meta.TransferSyntaxUID = pydicom.uid.ImplicitVRLittleEndian
     max_attempts = 2
     client.set_http_retry_params(
         retry=True,
@@ -1311,8 +1311,8 @@ def test_store_instance_error_with_retries_and_additional_params(
     httpserver, client, cache_dir
 ):
     dataset = pydicom.Dataset.from_json({})
-    dataset.is_little_endian = True
-    dataset.is_implicit_VR = True
+    dataset.file_meta = pydicom.dataset.FileMetaDataset()
+    dataset.file_meta.TransferSyntaxUID = pydicom.uid.ImplicitVRLittleEndian
     max_attempts = 2
     client.set_http_retry_params(
         retry=True,
@@ -1339,8 +1339,8 @@ def test_store_instance_error_with_retries_and_additional_params(
 
 def test_store_instance_error_with_no_retries(httpserver, client, cache_dir):
     dataset = pydicom.Dataset.from_json({})
-    dataset.is_little_endian = True
-    dataset.is_implicit_VR = True
+    dataset.file_meta = pydicom.dataset.FileMetaDataset()
+    dataset.file_meta.TransferSyntaxUID = pydicom.uid.ImplicitVRLittleEndian
     client.set_http_retry_params(retry=False)
     httpserver.serve_content(
         content='',
@@ -1360,8 +1360,8 @@ def test_store_instance_error_with_no_retries_and_additional_params(
     httpserver, client, cache_dir
 ):
     dataset = pydicom.Dataset.from_json({})
-    dataset.is_little_endian = True
-    dataset.is_implicit_VR = True
+    dataset.file_meta = pydicom.dataset.FileMetaDataset()
+    dataset.file_meta.TransferSyntaxUID = pydicom.uid.ImplicitVRLittleEndian
     client.set_http_retry_params(retry=False)
     httpserver.serve_content(
         content='',


### PR DESCRIPTION
This closes #119.

Pydicom warning:
`get_frame_offsets is deprecated and will be removed in v4.0`

See instructions at https://github.com/pydicom/pydicom/blob/main/doc/release_notes/v3.0.0.rst that pydicom `get_frame_offsets` usage should be replaced with `parse_basic_offsets`.

This PR maintains compatibility with pydicom >=2.2 which is supported per the pyproject.toml:
https://github.com/ImagingDataCommons/dicomweb-client/blob/84663e1b7a5b681273b92443c364381875d3aa9b/pyproject.toml#L36

I discovered this deprecation usage while using pydicom 3 and latest dicomweb-client in the context of 3D Slicer as part of updating python packages to latest (https://github.com/Slicer/Slicer/pull/8844).

cc: @fedorov 